### PR TITLE
Closing watcher on `beforeunload` event fixes reload not working

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,17 @@ import chokidar from 'chokidar';
 let watcher = null;
 let reloadQueued = false;
 
+function closeWatcher() {
+  if (watcher !== null) {
+    watcher.close();
+    watcher = null;
+  }
+}
+
+const beforeunloadEventHandler = () => {
+  closeWatcher();
+};
+
 function doReload() {
   inkdrop.commands.dispatch(document.body, 'window:reload');
 }
@@ -61,11 +72,12 @@ export function activate() {
     .on('add', path => reload(path))
     .on('change', path => reload(path))
     .on('unlink', path => reload(path));
+
+  window.addEventListener('beforeunload', beforeunloadEventHandler);
 }
 
 export function deactivate() {
-  if (watcher !== null) {
-    watcher.close();
-    watcher = null;
-  }
+  closeWatcher();
+
+  window.removeEventListener('beforeunload', beforeunloadEventHandler);
 }


### PR DESCRIPTION
At some point this plugin stopped working for me (on macOS, Big Sur 11.6.2) 
I don't know if anyone else run into this issue, but I'm leaving this PR here with my fix just in case.

I first got the plugin working by closing the chokidar watcher before dispatching the `window:reload` command.

Then I noticed reloading from the devtools console with `inkdrop.commands.dispatch(document.body, 'window:reload');` or `inkdrop.reload()` worked only if the plugin was disabled.

Finally, I moved closing the watcher to a listener for the `beforeunload` event. This way, reloading from this plugin or manually from the console both work fine. 

Never mind this PR if it's just me or there's a better way to approach the issue. 